### PR TITLE
af/new zigbee2mqtt action bluprints

### DIFF
--- a/tradfri_2_button.yaml
+++ b/tradfri_2_button.yaml
@@ -1,0 +1,103 @@
+blueprint:
+  name: FINK - Tradfri 2 Button
+  description: "Controls a light with a switch given by ENTITY. \n\nShort Button press will toggle light for both Buttons (helpfull in darkness) \n\n Mode set to restart is mandatory for stop after long press to work."
+  domain: automation
+  input:
+    source_switch:
+      name: Tradfri Switch
+      description: The switch to trigger this automation.
+      selector:
+        device:
+          filter:
+            - integration: mqtt
+    target_light:
+      name: Target Light
+      description: The light you want to control.
+      selector:
+        target:
+
+alias: Tradfri 2 Button
+description: ""
+trigger:
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "on"
+    id: "on"
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "off"
+    id: "off"
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_up
+    id: long_press_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_down
+    id: long_press_down
+
+condition: []
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id:
+              - "on"
+        sequence:
+          - action: light.toggle
+            data: {}
+            target: !input target_light
+      - conditions:
+          - condition: trigger
+            id:
+              - "off"
+        sequence:
+          - action: light.toggle
+            data: {}
+            target: !input target_light
+      - conditions:
+          - condition: trigger
+            id:
+              - brightness_move_up
+        sequence:
+          - repeat:
+              sequence:
+                - action: light.turn_on
+                  data:
+                    brightness_step_pct: 5
+                    transition: 0.2
+                  target: !input target_light
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 0
+                    milliseconds: 200
+              count: 50
+      - conditions:
+          - condition: trigger
+            id:
+              - brightness_move_down
+        sequence:
+          - repeat:
+              sequence:
+                - action: light.turn_on
+                  data:
+                    transition: 0.2
+                    brightness_step_pct: -5
+                  target: !input target_light
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 0
+                    milliseconds: 200
+              count: 50
+
+mode: restart

--- a/tradfri_4_button.yaml
+++ b/tradfri_4_button.yaml
@@ -1,13 +1,13 @@
 blueprint:
   name: FINK - Tradfri 4 Button
-  description: "Controls a light with a switch given by ENTITY. \n\nShort Button press will toggle light for both Buttons (helpfull in darkness) \n\n Mode set to restart is mandatory for stop after long press to work."
+  description: "Controls a light with a switch given by device. \n\nShort Button press will toggle light for both Buttons (helpfull in darkness) \n\n Mode set to restart is mandatory for stop after long press to work."
   domain: automation
   input:
     source_switch:
       name: Tradfri E1743 Switch
       description: The switch to trigger this automation.
       selector:
-        entity:
+        device:
           filter:
             - integration: mqtt
     target_light:

--- a/tradfri_4_button.yaml
+++ b/tradfri_4_button.yaml
@@ -94,7 +94,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - brightness_move_up
+              - long_press_up
         sequence:
           - repeat:
               sequence:
@@ -112,7 +112,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - brightness_move_down
+              - long_press_down
         sequence:
           - repeat:
               sequence:

--- a/tradfri_4_button.yaml
+++ b/tradfri_4_button.yaml
@@ -3,71 +3,75 @@ blueprint:
   description: "Controls a light with a switch given by ENTITY. \n\nShort Button press will toggle light for both Buttons (helpfull in darkness) \n\n Mode set to restart is mandatory for stop after long press to work."
   domain: automation
   input:
-    source_switch_e1743_action:
+    source_switch:
       name: Tradfri E1743 Switch
-      description: The switch-action which triggers this automation.
+      description: The switch to trigger this automation.
       selector:
         entity:
           filter:
             - integration: mqtt
-              domain: sensor
     target_light:
       name: Target Light
-      description: the light you want to control.
+      description: The light you want to control.
       selector:
         target:
     target_light_2:
       name: Target Light 2
-      description: the light you want to control with the left and right button
+      description: The light you want to control with the left and right button.
       selector:
         target:
 alias: Tradfri 4 Button
 description: ""
 trigger:
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "on"
     id: "on"
-    to: "on"
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "off"
     id: "off"
-    to: "off"
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_move_up
-    to: brightness_move_up
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_move_down
-    to: brightness_move_down
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_stop
-    to: brightness_stop
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_up
+    id: long_press_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_down
+    id: long_press_down
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_left_click
     id: arrow_left_click
-    to: arrow_left_click
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_right_click
     id: arrow_right_click
-    to: arrow_right_click
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_left_hold
     id: arrow_left_hold
-    to: arrow_left_hold
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_right_hold
     id: arrow_right_hold
-    to: arrow_right_hold
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: arrow_left_release
-    to: arrow_left_release
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: arrow_right_release
-    to: arrow_right_release
+
 condition: []
 action:
   - choose:
@@ -76,7 +80,7 @@ action:
             id:
               - "on"
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light
       - conditions:
@@ -84,7 +88,7 @@ action:
             id:
               - "off"
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light
       - conditions:
@@ -94,7 +98,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     brightness_step_pct: 5
                     transition: 0.2
@@ -112,7 +116,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     transition: 0.2
                     brightness_step_pct: -5
@@ -128,7 +132,7 @@ action:
             id:
               - arrow_right_click
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light_2
       - conditions:
@@ -136,7 +140,7 @@ action:
             id:
               - arrow_left_click
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light_2
       - conditions:
@@ -146,7 +150,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     brightness_step_pct: 5
                     transition: 0.2
@@ -164,7 +168,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     transition: 0.2
                     brightness_step_pct: -5

--- a/tradfri_4_button_1_light.yaml
+++ b/tradfri_4_button_1_light.yaml
@@ -113,7 +113,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - brightness_move_up
+              - long_press_up
         sequence:
           - repeat:
               sequence:
@@ -131,7 +131,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - brightness_move_down
+              - long_press_down
         sequence:
           - repeat:
               sequence:

--- a/tradfri_4_button_1_light.yaml
+++ b/tradfri_4_button_1_light.yaml
@@ -1,13 +1,13 @@
 blueprint:
   name: FINK - Tradfri 4 Button 1 Light
-  description: "Controls a light with a switch given by ENTITY. \n\nShort Button press will toggle light for both Buttons (helpfull in darkness) \n\n Mode set to restart is mandatory for stop after long press to work.\n\nAlso 4 custom actions for the arrow keys"
+  description: "Controls a light with a switch given by device. \n\nShort Button press will toggle light for both Buttons (helpfull in darkness) \n\n Mode set to restart is mandatory for stop after long press to work.\n\nAlso 4 custom actions for the arrow keys"
   domain: automation
   input:
-    source_switch_e1743_action:
+    source_switch:
       name: Tradfri E1743 Switch
       description: The switch-action which triggers this automation.
       selector:
-        entity:
+        device:
           filter:
             - integration: mqtt
     target_light:

--- a/tradfri_4_button_1_light.yaml
+++ b/tradfri_4_button_1_light.yaml
@@ -10,7 +10,6 @@ blueprint:
         entity:
           filter:
             - integration: mqtt
-              domain: sensor
     target_light:
       name: Target Light
       description: the light you want to control.
@@ -43,50 +42,55 @@ blueprint:
 alias: Tradfri 4 Button 1 Light
 description: ""
 trigger:
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "on"
     id: "on"
-    to: "on"
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "off"
     id: "off"
-    to: "off"
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_move_up
-    to: brightness_move_up
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_move_down
-    to: brightness_move_down
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_stop
-    to: brightness_stop
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_up
+    id: long_press_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_down
+    id: long_press_down
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_left_click
     id: arrow_left_click
-    to: arrow_left_click
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_right_click
     id: arrow_right_click
-    to: arrow_right_click
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_left_hold
     id: arrow_left_hold
-    to: arrow_left_hold
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_right_hold
     id: arrow_right_hold
-    to: arrow_right_hold
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: arrow_left_release
-    to: arrow_left_release
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: arrow_right_release
-    to: arrow_right_release
+
 condition: []
 action:
   - choose:
@@ -95,7 +99,7 @@ action:
             id:
               - "on"
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light
       - conditions:
@@ -103,7 +107,7 @@ action:
             id:
               - "off"
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light
       - conditions:
@@ -113,7 +117,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     brightness_step_pct: 5
                     transition: 0.2
@@ -131,7 +135,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     transition: 0.2
                     brightness_step_pct: -5

--- a/tradfri_4_button_set_brightness.yaml
+++ b/tradfri_4_button_set_brightness.yaml
@@ -3,11 +3,11 @@ blueprint:
   description: "This blueprint allows control of a light using a Tradfri E1743 switch. It toggles the light, adjusts brightness in steps, and sets specific brightness levels with button presses and holds. Customize brightness levels and transitions for a flexible lighting experience."
   domain: automation
   input:
-    source_switch_e1743_action:
+    source_switch:
       name: Tradfri E1743 Switch
       description: The switch-action which triggers this automation.
       selector:
-        entity:
+        device:
           filter:
             - integration: mqtt
     target_light:

--- a/tradfri_4_button_set_brightness.yaml
+++ b/tradfri_4_button_set_brightness.yaml
@@ -134,7 +134,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - brightness_move_up
+              - long_press_up
         sequence:
           - repeat:
               sequence:
@@ -152,7 +152,7 @@ action:
       - conditions:
           - condition: trigger
             id:
-              - brightness_move_down
+              - long_press_down
         sequence:
           - repeat:
               sequence:

--- a/tradfri_4_button_set_brightness.yaml
+++ b/tradfri_4_button_set_brightness.yaml
@@ -10,7 +10,6 @@ blueprint:
         entity:
           filter:
             - integration: mqtt
-              domain: sensor
     target_light:
       name: Target Light
       description: the light you want to control.
@@ -24,7 +23,7 @@ blueprint:
         number:
           min: 0
           max: 100
-          unit_of_measurement: '%'
+          unit_of_measurement: "%"
     left_hold_bright:
       name: Left Hold Click Brightness
       description: "Brightness when the left arrow key is hold"
@@ -33,7 +32,7 @@ blueprint:
         number:
           min: 0
           max: 100
-          unit_of_measurement: '%'
+          unit_of_measurement: "%"
     right_click_bright:
       name: Right Click Brightness
       description: "Brightness when the right arrow key is pressed"
@@ -42,7 +41,7 @@ blueprint:
         number:
           min: 0
           max: 100
-          unit_of_measurement: '%'
+          unit_of_measurement: "%"
     right_hold_bright:
       name: Right Hold Click Brightness
       description: "Brightness when the right arrow key is hold"
@@ -51,7 +50,7 @@ blueprint:
         number:
           min: 0
           max: 100
-          unit_of_measurement: '%'
+          unit_of_measurement: "%"
     transition_length:
       name: Transition length
       description: "Length of the transition"
@@ -60,54 +59,59 @@ blueprint:
         number:
           min: 0
           max: 10
-          unit_of_measurement: 's'
+          unit_of_measurement: "s"
 alias: Tradfri 4 Button 1 Light
 description: ""
 trigger:
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "on"
     id: "on"
-    to: "on"
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: "off"
     id: "off"
-    to: "off"
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_move_up
-    to: brightness_move_up
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_move_down
-    to: brightness_move_down
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: brightness_stop
-    to: brightness_stop
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_up
+    id: long_press_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: brightness_move_down
+    id: long_press_down
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_left_click
     id: arrow_left_click
-    to: arrow_left_click
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_right_click
     id: arrow_right_click
-    to: arrow_right_click
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_left_hold
     id: arrow_left_hold
-    to: arrow_left_hold
-  - platform: state
-    entity_id: !input source_switch_e1743_action
+  - trigger: device
+    domain: mqtt
+    device_id: !input source_switch
+    type: action
+    subtype: arrow_right_hold
     id: arrow_right_hold
-    to: arrow_right_hold
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: arrow_left_release
-    to: arrow_left_release
-  - platform: state
-    entity_id: !input source_switch_e1743_action
-    id: arrow_right_release
-    to: arrow_right_release
+
 condition: []
 action:
   - choose:
@@ -116,7 +120,7 @@ action:
             id:
               - "on"
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light
       - conditions:
@@ -124,7 +128,7 @@ action:
             id:
               - "off"
         sequence:
-          - service: light.toggle
+          - action: light.toggle
             data: {}
             target: !input target_light
       - conditions:
@@ -134,7 +138,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     brightness_step_pct: 5
                     transition: 0.2
@@ -152,7 +156,7 @@ action:
         sequence:
           - repeat:
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     transition: 0.2
                     brightness_step_pct: -5
@@ -168,7 +172,7 @@ action:
             id:
               - arrow_right_click
         sequence:
-          - service: light.turn_on
+          - action: light.turn_on
             data:
               brightness_pct: !input right_click_bright
               transition: !input transition_length
@@ -178,7 +182,7 @@ action:
             id:
               - arrow_left_click
         sequence:
-          - service: light.turn_on
+          - action: light.turn_on
             data:
               brightness_pct: !input left_click_bright
               transition: !input transition_length
@@ -188,7 +192,7 @@ action:
             id:
               - arrow_right_hold
         sequence:
-          - service: light.turn_on
+          - action: light.turn_on
             data:
               brightness_pct: !input right_hold_bright
               transition: !input transition_length
@@ -198,11 +202,10 @@ action:
             id:
               - arrow_left_hold
         sequence:
-          - service: light.turn_on
+          - action: light.turn_on
             data:
               brightness_pct: !input left_hold_bright
               transition: !input transition_length
             target: !input target_light
 mode: restart
 max_exceeded: silent
-


### PR DESCRIPTION
After the update of zigbee2mqtt to version 2.0 the sensor.*action is depicted, the [recommended](https://www.zigbee2mqtt.io/guide/usage/integrations/home_assistant.html#via-mqtt-device-trigger-recommended) way now is to use this pull request implements this for the 4 button blueprints 